### PR TITLE
fix(#527): auto-create missing status directory on first start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <mainClass>no.cantara.realestate.metasys.cloudconnector.MetasysCloudconnectorApplication</mainClass>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.19.0</jackson.version>
         <slf4j.version>1.7.32</slf4j.version>
         <logback.version>1.2.6</logback.version>
         <slf4j.version>2.0.7</slf4j.version>
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.22</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/src/main/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedService.java
+++ b/src/main/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedService.java
@@ -45,7 +45,14 @@ public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
         Path directoryPath = Paths.get(lastUpdatedDirectory);
 
         if (!Files.exists(directoryPath)) {
-            throw new IllegalArgumentException("Directory does not exist: " + lastUpdatedDirectory + ". Please create the directory before restarting.");
+            try {
+                Files.createDirectories(directoryPath);
+                log.info("Created directory for trend tracking: {}", directoryPath.toAbsolutePath());
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Directory does not exist and could not be created: " + directoryPath.toAbsolutePath() +
+                        ". Please create the directory manually before restarting.", e);
+            }
         }
         this.lastUpdatedFile = directoryPath.resolve(lastUpdatedFile).toFile();
         if (!this.lastUpdatedFile.exists()) {

--- a/src/test/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedServiceTest.java
+++ b/src/test/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedServiceTest.java
@@ -1,0 +1,69 @@
+package no.cantara.realestate.metasys.cloudconnector.trends;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CsvTrendsLastUpdatedServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void constructor_withExistingDirectory_succeeds() {
+        String dir = tempDir.toString();
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(
+                dir, "last_updated.csv", "last_failed.csv");
+
+        assertNotNull(service);
+        assertTrue(new File(dir, "last_updated.csv").exists(), "last_updated.csv should be created");
+        assertTrue(new File(dir, "last_failed.csv").exists(), "last_failed.csv should be created");
+    }
+
+    @Test
+    void constructor_withMissingDirectory_createsItAutomatically() {
+        // Regression test for issue #527: first start should not fail when status dir is missing
+        Path missing = tempDir.resolve("status");
+        assertFalse(missing.toFile().exists(), "Directory should not exist yet");
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(
+                missing.toString(), "last_updated.csv", "last_failed.csv");
+
+        assertNotNull(service);
+        assertTrue(missing.toFile().exists(), "Directory should have been created automatically");
+        assertTrue(missing.resolve("last_updated.csv").toFile().exists());
+        assertTrue(missing.resolve("last_failed.csv").toFile().exists());
+    }
+
+    @Test
+    void constructor_withNestedMissingDirectories_createsThemAutomatically() {
+        Path nested = tempDir.resolve("a/b/status");
+        assertFalse(nested.toFile().exists());
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(
+                nested.toString(), "last_updated.csv", "last_failed.csv");
+
+        assertNotNull(service);
+        assertTrue(nested.toFile().exists());
+    }
+
+    @Test
+    void constructor_csvFilesAreCreatedWithHeaders() {
+        Path statusDir = tempDir.resolve("status");
+
+        new CsvTrendsLastUpdatedService(statusDir.toString(), "last_updated.csv", "last_failed.csv");
+
+        File updatedFile = statusDir.resolve("last_updated.csv").toFile();
+        File failedFile = statusDir.resolve("last_failed.csv").toFile();
+
+        assertTrue(updatedFile.exists());
+        assertTrue(failedFile.exists());
+        assertTrue(updatedFile.length() > 0, "last_updated.csv should contain the CSV header");
+        assertTrue(failedFile.length() > 0, "last_failed.csv should contain the CSV header");
+    }
+}


### PR DESCRIPTION
Fixes #527

## Summary

- **Root cause**: `CsvTrendsLastUpdatedService` threw `IllegalArgumentException` when the configured directory (`status` by default) did not exist, crashing the application on first start instead of creating it.
- **Fix**: Replace the throw with `Files.createDirectories()` — directory and any missing parents are created automatically. If creation fails the error message now includes the full absolute path.
- **Bonus fix**: Renovate incorrectly bumped `jackson.version` to `2.22.0`, which does not exist on Maven Central (confused with `commons-io:2.22.0`, which is real). Corrected to `2.19.0` (latest published Jackson release) and aligned `jackson-annotations` to use the shared `${jackson.version}` property.

## Test plan

- [x] `CsvTrendsLastUpdatedServiceTest` — 4 new tests: existing dir, missing dir, nested missing dirs, CSV headers written on creation
- [x] Full test suite: 99 tests, 0 failures, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)