### PR TITLE
fix(trends): key trends_last_updated by sensorId, merge on persist (#535)

### DIFF
--- a/src/main/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedService.java
+++ b/src/main/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedService.java
@@ -22,8 +22,16 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Deprecated //Use no.cantara.realestate.cloudconnector.trends.CsvTrendsLastUpdatedService instead
 public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
     private static final Logger log = getLogger(CsvTrendsLastUpdatedService.class);
-    Map<MetasysSensorId, Instant> lastUpdated;
-    Map<MetasysSensorId, Instant> lastFailed;
+
+    // Identity is the SensorId (the "Sensor-..." twinId). metasysObjectId is extra info, kept only
+    // as an output column for readability - it is intentionally NOT part of the key. Keying by the
+    // full MetasysSensorId would fold metasysObjectReference into equals/hashCode, and since the
+    // reference is never persisted it can never round-trip, so reloaded keys could never match the
+    // live subscription keys. See issue #535.
+    Map<String, Instant> lastUpdated;
+    Map<String, Instant> lastFailed;
+    // sensorId -> metasysObjectId, purely for the output column.
+    private final Map<String, String> metasysObjectIdById = new HashMap<>();
 
     // CSV file headers
     // lastUpdatedFile: sensorId, metasysObjectId, lastUpdatedAt
@@ -34,10 +42,6 @@ public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
     public CsvTrendsLastUpdatedService() {
         lastUpdated = new HashMap<>();
         lastFailed = new HashMap<>();
-    }
-
-    public CsvTrendsLastUpdatedService(Map<MetasysSensorId, Instant> lastUpdated) {
-        this.lastUpdated = lastUpdated;
     }
 
     public CsvTrendsLastUpdatedService(String lastUpdatedDirectory, String lastUpdatedFile, String lastFailedFile) {
@@ -81,10 +85,10 @@ public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
             String metasysObjectId = record.get("metasysObjectId");
             String lastUpdatedAtStr = record.get("lastUpdatedAt");
 
-            if (sensorId != null && metasysObjectId != null && lastUpdatedAtStr != null) {
-                MetasysSensorId id = new MetasysSensorId(sensorId, metasysObjectId, null);
+            if (sensorId != null && lastUpdatedAtStr != null) {
                 Instant lastUpdatedAt = Instant.parse(lastUpdatedAtStr);
-                lastUpdated.put(id, lastUpdatedAt);
+                lastUpdated.put(sensorId, lastUpdatedAt);
+                rememberMetasysObjectId(sensorId, metasysObjectId);
             }
         }
         log.info("Read {} last updated records from {}", lastUpdated.size(), lastUpdatedFile.getAbsolutePath());
@@ -95,55 +99,54 @@ public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
             String metasysObjectId = record.get("metasysObjectId");
             String lastFailedAtStr = record.get("lastFailedAt");
 
-            if (sensorId != null && metasysObjectId != null && lastFailedAtStr != null) {
-                MetasysSensorId id = new MetasysSensorId(sensorId, metasysObjectId, null);
+            if (sensorId != null && lastFailedAtStr != null) {
                 Instant lastFailedAt = Instant.parse(lastFailedAtStr);
-                lastFailed.put(id, lastFailedAt);
+                lastFailed.put(sensorId, lastFailedAt);
+                rememberMetasysObjectId(sensorId, metasysObjectId);
             }
         }
     }
 
     @Override
     public Instant getLastUpdatedAt(SensorId sensorId) {
-        Instant matchedLastUpdatedAt = lastUpdated.entrySet().stream()
-                .filter(entry -> entry.getKey().getId().equals(sensorId.getId()))
-                .map(Map.Entry::getValue)
-                .findFirst()
-                .orElse(null);
-        return matchedLastUpdatedAt;
+        if (sensorId == null || sensorId.getId() == null) {
+            return null;
+        }
+        return lastUpdated.get(sensorId.getId());
     }
 
 
     @Override
     public <T extends SensorId>  void setLastUpdatedAt(SensorId sensorId, Instant lastUpdatedAt) {
-        if ( sensorId instanceof  MetasysSensorId && sensorId != null && lastUpdatedAt != null) {
-            Instant currentLastUpdatedAt = lastUpdated.get(sensorId);
+        if (sensorId != null && sensorId.getId() != null && lastUpdatedAt != null) {
+            String id = sensorId.getId();
+            Instant currentLastUpdatedAt = lastUpdated.get(id);
             if (currentLastUpdatedAt == null || currentLastUpdatedAt.isBefore(lastUpdatedAt)) {
-                lastUpdated.put((MetasysSensorId) sensorId, lastUpdatedAt);
+                lastUpdated.put(id, lastUpdatedAt);
             }
+            rememberMetasysObjectId(sensorId);
         }
     }
 
     @Override
     public <T extends SensorId> void setLastFailedAt(SensorId sensorId, Instant lastFailedAt) {
-        if(sensorId instanceof MetasysSensorId && sensorId != null && lastFailedAt != null) {
-            lastFailed.put((MetasysSensorId) sensorId, lastFailedAt);
+        if (sensorId != null && sensorId.getId() != null && lastFailedAt != null) {
+            lastFailed.put(sensorId.getId(), lastFailedAt);
+            rememberMetasysObjectId(sensorId);
         }
     }
 
     @Override
     public <T extends SensorId> void persistLastFailed(List<T> sensorIds) {
-        log.info("Persisting last failed for {} sensors", sensorIds.size());
+        // Merge: persist everything we know, not just the sensors handled this cycle, so quiet
+        // sensors are not dropped from the file on rewrite. See issue #535.
+        rememberMetasysObjectIds(sensorIds);
+        log.info("Persisting last failed for {} sensors", lastFailed.size());
         try (BufferedWriter writer = Files.newBufferedWriter(lastFailedFile.toPath())) {
             writer.write("sensorId,metasysObjectId,lastFailedAt\n");
-            for (T sensorId : sensorIds) {
-                if (sensorId instanceof MetasysSensorId) {
-                    MetasysSensorId id = (MetasysSensorId) sensorId;
-                    Instant lastFailedAt = lastFailed.get(id);
-                    if (lastFailedAt != null) {
-                        writer.write(String.format("%s,%s,%s\n", id.getId(), id.getMetasysObjectId(), lastFailedAt));
-                    }
-                }
+            for (Map.Entry<String, Instant> entry : lastFailed.entrySet()) {
+                writer.write(String.format("%s,%s,%s\n", entry.getKey(),
+                        metasysObjectIdById.getOrDefault(entry.getKey(), ""), entry.getValue()));
             }
         } catch (Exception e) {
             log.error("Failed to persist last failed data to file: {}", lastFailedFile.getAbsolutePath(), e);
@@ -152,20 +155,39 @@ public class CsvTrendsLastUpdatedService implements TrendsLastUpdatedService {
 
     @Override
     public <T extends SensorId> void persistLastUpdated(List<T> sensorIds) {
-        log.info("Persisting last updated for {} sensors", sensorIds.size());
+        // Merge: persist everything we know, not just the sensors handled this cycle, so quiet
+        // sensors are not dropped from the file on rewrite. See issue #535.
+        rememberMetasysObjectIds(sensorIds);
+        log.info("Persisting last updated for {} sensors", lastUpdated.size());
         try (BufferedWriter writer = Files.newBufferedWriter(lastUpdatedFile.toPath())) {
             writer.write("sensorId,metasysObjectId,lastUpdatedAt\n");
-            for (T sensorId : sensorIds) {
-                if (sensorId instanceof MetasysSensorId) {
-                    MetasysSensorId id = (MetasysSensorId) sensorId;
-                    Instant lastUpdatedAt = lastUpdated.get(id);
-                    if (lastUpdatedAt != null) {
-                        writer.write(String.format("%s,%s,%s\n", id.getId(), id.getMetasysObjectId(), lastUpdatedAt));
-                    }
-                }
+            for (Map.Entry<String, Instant> entry : lastUpdated.entrySet()) {
+                writer.write(String.format("%s,%s,%s\n", entry.getKey(),
+                        metasysObjectIdById.getOrDefault(entry.getKey(), ""), entry.getValue()));
             }
         } catch (Exception e) {
             log.error("Failed to persist last updated data to file: {}", lastUpdatedFile.getAbsolutePath(), e);
+        }
+    }
+
+    private <T extends SensorId> void rememberMetasysObjectIds(List<T> sensorIds) {
+        if (sensorIds == null) {
+            return;
+        }
+        for (T sensorId : sensorIds) {
+            rememberMetasysObjectId(sensorId);
+        }
+    }
+
+    private void rememberMetasysObjectId(SensorId sensorId) {
+        if (sensorId instanceof MetasysSensorId && sensorId.getId() != null) {
+            rememberMetasysObjectId(sensorId.getId(), ((MetasysSensorId) sensorId).getMetasysObjectId());
+        }
+    }
+
+    private void rememberMetasysObjectId(String sensorId, String metasysObjectId) {
+        if (sensorId != null && metasysObjectId != null && !metasysObjectId.isEmpty()) {
+            metasysObjectIdById.put(sensorId, metasysObjectId);
         }
     }
 

--- a/src/test/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedServiceTest.java
+++ b/src/test/java/no/cantara/realestate/metasys/cloudconnector/trends/CsvTrendsLastUpdatedServiceTest.java
@@ -1,10 +1,13 @@
 package no.cantara.realestate.metasys.cloudconnector.trends;
 
+import no.cantara.realestate.sensors.metasys.MetasysSensorId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -65,5 +68,76 @@ class CsvTrendsLastUpdatedServiceTest {
         assertTrue(failedFile.exists());
         assertTrue(updatedFile.length() > 0, "last_updated.csv should contain the CSV header");
         assertTrue(failedFile.length() > 0, "last_failed.csv should contain the CSV header");
+    }
+
+    // Regression for #535: the lastUpdatedAt must survive a persist/restart round-trip even though
+    // metasysObjectReference is not persisted. Identity is the SensorId, not the full MetasysSensorId.
+    @Test
+    void lastUpdated_survivesRestart_evenWhenSensorHasObjectReference() {
+        String dir = tempDir.toString();
+        MetasysSensorId sensor = new MetasysSensorId("Sensor-aaa", "obj-1", "METASYS1:RE1-NAE7/some.reference");
+        Instant t1 = Instant.parse("2026-06-10T10:00:00Z");
+
+        CsvTrendsLastUpdatedService before = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        before.setLastUpdatedAt(sensor, t1);
+        before.persistLastUpdated(List.of(sensor));
+
+        // Simulate restart: a fresh instance reads from disk (reference is lost -> reconstructed as null).
+        CsvTrendsLastUpdatedService after = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        after.readLastUpdated();
+
+        assertEquals(t1, after.getLastUpdatedAt(sensor),
+                "lastUpdatedAt must be found after restart regardless of metasysObjectReference");
+    }
+
+    // Regression for #535: lookups match on sensorId only; metasysObjectReference is irrelevant.
+    @Test
+    void getLastUpdatedAt_matchesById_ignoringObjectReference() {
+        String dir = tempDir.toString();
+        Instant t1 = Instant.parse("2026-06-10T10:00:00Z");
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        service.setLastUpdatedAt(new MetasysSensorId("Sensor-aaa", "obj-1", "ref-A"), t1);
+
+        // Query with the same id but a different (or absent) reference.
+        assertEquals(t1, service.getLastUpdatedAt(new MetasysSensorId("Sensor-aaa", "obj-1", null)));
+        assertEquals(t1, service.getLastUpdatedAt(new MetasysSensorId("Sensor-aaa", "obj-1", "ref-B")));
+    }
+
+    // Regression for #535: persist must merge, not drop, sensors that were not touched this cycle.
+    @Test
+    void persistLastUpdated_retainsQuietSensors() {
+        String dir = tempDir.toString();
+        MetasysSensorId quiet = new MetasysSensorId("Sensor-quiet", "obj-q", "ref-q");
+        MetasysSensorId active = new MetasysSensorId("Sensor-active", "obj-a", "ref-a");
+        Instant tQuiet = Instant.parse("2026-06-10T08:00:00Z");
+        Instant tActive = Instant.parse("2026-06-10T09:00:00Z");
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        service.setLastUpdatedAt(quiet, tQuiet);
+        service.setLastUpdatedAt(active, tActive);
+
+        // A cycle where only 'active' was processed must not drop 'quiet'.
+        service.persistLastUpdated(List.of(active));
+
+        CsvTrendsLastUpdatedService reloaded = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        reloaded.readLastUpdated();
+        assertEquals(tQuiet, reloaded.getLastUpdatedAt(quiet), "quiet sensor must be retained across persist");
+        assertEquals(tActive, reloaded.getLastUpdatedAt(active));
+    }
+
+    // Regression for #535: a newer observation advances the stored timestamp; an older one does not.
+    @Test
+    void setLastUpdatedAt_keepsTheLatestTimestamp() {
+        String dir = tempDir.toString();
+        MetasysSensorId sensor = new MetasysSensorId("Sensor-aaa", "obj-1", "ref-A");
+        Instant older = Instant.parse("2026-06-10T10:00:00Z");
+        Instant newer = Instant.parse("2026-06-10T11:00:00Z");
+
+        CsvTrendsLastUpdatedService service = new CsvTrendsLastUpdatedService(dir, "last_updated.csv", "last_failed.csv");
+        service.setLastUpdatedAt(sensor, newer);
+        service.setLastUpdatedAt(sensor, older); // out-of-order/late sample must not roll back
+
+        assertEquals(newer, service.getLastUpdatedAt(sensor));
     }
 }


### PR DESCRIPTION
Fixes #535.

## Problem
`status/trends_last_updated.csv` advanced for some sensors but froze at the startup value (or dropped rows) for others.

`CsvTrendsLastUpdatedService` keyed its in-memory map by `MetasysSensorId`, whose `equals`/`hashCode` (inherited from `SensorId`) fold the entire `identifiers` map — including `metasysObjectReference` — into identity. The reference is **never persisted**, so a key reloaded from disk (`ref=null`) could never equal the live subscription key (`ref="…"` or `""` for an empty CSV cell). Worse, the map was read leniently (`getLastUpdatedAt` matches by `getId()`) but written strictly (`Map.get(key)` in `setLastUpdatedAt`/`persistLastUpdated`), and `persistLastUpdated` truncates+rewrites the file from only the current cycle's sensors. Net effect: sensors with no fresh sample in a cycle were dropped/frozen.

See the issue for the full per-cycle trace.

## Change
- Key `lastUpdated` / `lastFailed` by **`sensorId.getId()`** (a `String`) everywhere — read, get, set, persist — matching what `getLastUpdatedAt` already assumed. `metasysObjectId` is kept only as an output column for readability; it is not identity.
- `persistLastUpdated` / `persistLastFailed` now **merge**: they write every known entry, not just the sensors handled this cycle, so quiet sensors are no longer dropped.
- `SensorId.equals`/`hashCode` in `realestate-typelib-java` is **left unchanged** — that equality is shared widely; the persistence layer now owns its identity.

## Tests
Added regression tests to `CsvTrendsLastUpdatedServiceTest`:
- `lastUpdated_survivesRestart_evenWhenSensorHasObjectReference` — persist → fresh instance → `readLastUpdated` → value still found.
- `getLastUpdatedAt_matchesById_ignoringObjectReference`.
- `persistLastUpdated_retainsQuietSensors` — merge-on-persist.
- `setLastUpdatedAt_keepsTheLatestTimestamp` — late samples don't roll back.

All trends + ingestion tests pass (`CsvTrendsLastUpdatedServiceTest` 8/8, `MetasysTrendsIngestionService*` 28/28).

## Notes / follow-ups
- Stream-fed sensors still don't update the file — tracked separately in #536 (depends on this PR).
- The non-deprecated `no.cantara.realestate.cloudconnector.trends.CsvTrendsLastUpdatedService` in `realestate-cloudconnector-agent` has the identical flaw and should get the same fix when migrated to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)